### PR TITLE
Replaced social icons with the relative path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,14 +1,25 @@
 # Site settings
-title: Strata
-email: your-email@domain.com
+
+title: Strata # Title of your site
+email: your-email@domain.com # Your contant email
+
 description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://yourdomain.com" # the base hostname & protocol for your site
-twitter_username: jekyllrb
-github_username:  jekyll
+
+# Social links.
+# Replace the word 'example' with your username if you want to include the icon in the left sidebar
+# Delete the word 'example' if you don't want to include the icon in the left sidebar
+
+twitter_username:     example  # Replace this with your Twitter username
+github_username:      example  # Replace this with your GitHub username
+linkedin_username:    example  # Replace this with your LinkedIn username
+google_plus_username: example  # Replace this with your Google+ username
+facebook_username:    example  # Replace this with your Facebook username
+dribbble_username:    example  # Replace this with your Dribbble username
 
 # Build settings
 markdown: kramdown

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,10 +33,62 @@
         <!-- Footer -->
         <footer id="footer">
             <ul class="icons">
-                <li><a href="#" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
-                <li><a href="#" class="icon fa-github"><span class="label">Github</span></a></li>
-                <li><a href="#" class="icon fa-dribbble"><span class="label">Dribbble</span></a></li>
-                <li><a href="#" class="icon fa-envelope-o"><span class="label">Email</span></a></li>
+
+              {% if site.github_username %}
+              <li>
+                <a href="https://github.com/{{ site.github_username }}" class="icon fa-github">
+                  <span class="label">GitHub</span>
+                </a>
+              </li>
+              {% endif %}
+
+              {% if site.twitter_username %}
+              <li>
+                <a href="https://twitter.com/{{ site.twitter_username }}" class="icon fa-twitter">
+                  <span class="label">Twitter</span>
+                </a>
+              </li>
+              {% endif %}
+
+              {% if site.linkedin_username %}
+              <li>
+                <a href="https://linkedin.com/in/{{ site.linkedin_username }}" class="icon fa-linkedin">
+                  <span class="label">LinkedIn</span>
+                </a>
+              </li>
+              {% endif %}
+
+              {% if site.google_plus_username %}
+              <li>
+                <a href="https://plus.google.com/{{ site.google_plus_username }}" class="icon fa-google-plus">
+                  <span class="label">Google+</span>
+                </a>
+              </li>
+              {% endif %}
+
+              {% if site.facebook_username %}
+              <li>
+                <a href="https://www.facebook.com/{{ site.facebook_username }}" class="icon fa-facebook">
+                  <span class="label">Facebook</span>
+                </a>
+              </li>
+              {% endif %}
+
+              {% if site.dribbble_username %}
+              <li>
+                <a href="#" class="icon fa-dribbble">
+                  <span class="label">Dribbble</span>
+                </a>
+              </li>
+              {% endif %}
+
+              {% if site.email %}
+              <li>
+                <a href="mailto:{{ site.email }}" class="icon fa-envelope-o">
+                  <span class="label">Email</span>
+                </a>
+              </li>
+              {% endif %}
             </ul>
             <ul class="copyright">
                 <li>&copy; Untitled</li>


### PR DESCRIPTION
I noticed that the social media icons are hard-coded in HTML without creating a simple option to change them.

I changed the `_config.yml` to include more sites: Twitter, GitHub, LinkedIn, Google+, Facebook and Dribbble.

After that, I edited the `/_layouts/default.html`. Now code checks if there's a username stated in the `_config.yml` file. If there's no username in that file for some social site, the will be no icon for that site in the left sidebar.

I put all of the usernames to `example` so all of the icons are shown right now.
