### PR TITLE
Fix typo in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 
 title: Strata # Title of your site
-email: your-email@domain.com # Your contant email
+email: your-email@domain.com # Your contact email
 
 description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this


### PR DESCRIPTION
Noticed a small typo in _config.yml where "contact" was spelled "contant".
